### PR TITLE
Flips container on landing page.

### DIFF
--- a/frontend/packages/client/src/App.sass
+++ b/frontend/packages/client/src/App.sass
@@ -595,6 +595,11 @@ span[data-tooltip]
 	-webkit-box-orient: vertical
 	overflow: hidden
 
+.line-clamp-1
+	display: -webkit-box
+	-webkit-line-clamp: 1
+	-webkit-box-orient: vertical
+	overflow: hidden
 .mx-loader
 	margin-left: 0.1rem !important
 	margin-right: 0.1rem !important

--- a/frontend/packages/client/src/components/BrowseButton.js
+++ b/frontend/packages/client/src/components/BrowseButton.js
@@ -1,15 +1,15 @@
 import { Link } from 'react-router-dom';
 
-export default function BrowseCommunityButton() {
+export default function BrowseButton({ path, label, styles }) {
   return (
-    <div className="mt-5">
+    <div className="mt-5" style={styles}>
       <div className="is-flex flex-1">
-        <Link to={`/browse-communities`}>
+        <Link to={path}>
           <div
             className="button is-fullwidth rounded-xl is-flex has-text-weight-bold has-background-white px-5"
             style={{ height: '48px', maxWidth: '220px' }}
           >
-            Browse All Communities
+            {label}
           </div>
         </Link>
       </div>

--- a/frontend/packages/client/src/components/FlipsContainer/FlipCardBody.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipCardBody.js
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { parseHTML } from 'utils';
+import { stripHtml } from 'string-strip-html';
+
+export default function FlipCardBody({ body, name }) {
+  const imgProps = useMemo(() => parseHTML(body, 'img'), [body]);
+  const {
+    src = 'https://dappercollectives.mypinata.cloud/ipfs/Qma6P7W9XV3pJJmH8vXwqnLnHw3svrNwgRFoBYmqvHwmZz',
+    alt = 'Dummy img',
+  } = imgProps;
+  return (
+    <>
+      <div className="is-flex column p-0 rounded-sm">
+        <img
+          src={src}
+          alt={alt}
+          style={{ height: '300px', width: '100%', objectFit: 'fill' }}
+        />
+      </div>
+      <div className="p-4">
+        <div className="is-size-4 line-clamp-1 has-text-weight-bold mb-2">
+          {name}
+        </div>
+
+        <p className="has-text-grey proposal-text-truncated">
+          {stripHtml(body || '').result}
+        </p>
+      </div>
+    </>
+  );
+}

--- a/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
@@ -1,4 +1,5 @@
 import { Svg } from '@cast/shared-components';
+import { StyledStatusPill } from 'components';
 import { FilterValues } from 'const';
 import { parseDateFromServer } from 'utils';
 
@@ -11,25 +12,19 @@ const STATUS_BUTTONS = {
     </button>
   ),
   [FilterValues.pending]: (
-    <button
-      class={`button is-rounded is-small has-text-weight-semibold has-background-orange has-border-orange`}
-    >
-      Upcoming...
-    </button>
+    <div className="pt-3">
+      <StyledStatusPill status={FilterValues.pending} />
+    </div>
   ),
   [FilterValues.closed]: (
-    <button
-      class={`button is-rounded is-small has-text-weight-semibold has-background-green has-border-green`}
-    >
-      Complete
-    </button>
+    <div className="pt-3">
+      <StyledStatusPill status={FilterValues.closed} />
+    </div>
   ),
   [FilterValues.cancelled]: (
-    <button
-      class={`button is-rounded is-small has-text-weight-semibold has-background-danger has-border-danger`}
-    >
-      Canceled
-    </button>
+    <div className="pt-3">
+      <StyledStatusPill status={FilterValues.cancelled} />
+    </div>
   ),
 };
 

--- a/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
@@ -1,32 +1,7 @@
 import { Svg } from '@cast/shared-components';
-import { StyledStatusPill } from 'components';
+import { StatusLabel, StyledStatusPill } from 'components';
 import { FilterValues } from 'const';
 import { parseDateFromServer } from 'utils';
-
-const STATUS_BUTTONS = {
-  [FilterValues.active]: (
-    <button
-      class={`button is-rounded is-small has-text-weight-semibold has-background-orange has-border-orange`}
-    >
-      Cast Your Vote
-    </button>
-  ),
-  [FilterValues.pending]: (
-    <div className="pt-3">
-      <StyledStatusPill status={FilterValues.pending} />
-    </div>
-  ),
-  [FilterValues.closed]: (
-    <div className="pt-3">
-      <StyledStatusPill status={FilterValues.closed} />
-    </div>
-  ),
-  [FilterValues.cancelled]: (
-    <div className="pt-3">
-      <StyledStatusPill status={FilterValues.cancelled} />
-    </div>
-  ),
-};
 
 const IconAndText = ({ endTime, status }) => {
   const { diffDuration } = parseDateFromServer(endTime);
@@ -40,42 +15,36 @@ const IconAndText = ({ endTime, status }) => {
   ) : null;
 };
 
+const getStatusComponent = (voted) => {
+  return {
+    [FilterValues.active]: (
+      <StatusLabel
+        status="Active"
+        voted={voted}
+        rounder
+        color="has-background-orange"
+        className="proposal-status-label has-text-weight-bold has-text-black"
+      />
+    ),
+    [FilterValues.pending]: <StyledStatusPill status={FilterValues.pending} />,
+    [FilterValues.closed]: <StyledStatusPill status={FilterValues.closed} />,
+    [FilterValues.cancelled]: (
+      <StyledStatusPill status={FilterValues.cancelled} />
+    ),
+  };
+};
+
 const FlipCardFooter = ({ id, voted, endTime, computedStatus }) => {
   const status = FilterValues[computedStatus] ?? FilterValues.closed;
 
   return (
-    <div className="px-4 pb-4 is-flex is-align-items-center">
-      {status === FilterValues.active && voted ? (
-        <span className="is-flex has-text-weight-bold is-size-7 pt-2 pb-1">
-          <Svg
-            name="CheckMark"
-            height="15"
-            width="15"
-            circleFill="white"
-            checkFill={'#F4AF4A'}
-            style={{
-              border: `2px solid #F4AF4A`,
-              borderRadius: '50%',
-              marginRight: '6.5px',
-            }}
-          />
-          You've Already Voted
-        </span>
-      ) : (
-        <>
-          <p className="has-text-grey px-0 smaller-text">
-            {STATUS_BUTTONS[status] ?? null}
-          </p>
-          <div className="is-flex ml-2">
-            <IconAndText
-              voted={voted}
-              endTime={endTime}
-              status={status}
-              id={id}
-            />
-          </div>
-        </>
-      )}
+    <div className="px-4 pb-5 pt-2 is-flex is-align-items-center">
+      <p className="has-text-grey px-0 smaller-text">
+        {getStatusComponent(voted)[status] ?? null}
+      </p>
+      <div className="is-flex ml-2">
+        <IconAndText voted={voted} endTime={endTime} status={status} id={id} />
+      </div>
     </div>
   );
 };

--- a/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipCardFooter.js
@@ -1,0 +1,88 @@
+import { Svg } from '@cast/shared-components';
+import { FilterValues } from 'const';
+import { parseDateFromServer } from 'utils';
+
+const STATUS_BUTTONS = {
+  [FilterValues.active]: (
+    <button
+      class={`button is-rounded is-small has-text-weight-semibold has-background-orange has-border-orange`}
+    >
+      Cast Your Vote
+    </button>
+  ),
+  [FilterValues.pending]: (
+    <button
+      class={`button is-rounded is-small has-text-weight-semibold has-background-orange has-border-orange`}
+    >
+      Upcoming...
+    </button>
+  ),
+  [FilterValues.closed]: (
+    <button
+      class={`button is-rounded is-small has-text-weight-semibold has-background-green has-border-green`}
+    >
+      Complete
+    </button>
+  ),
+  [FilterValues.cancelled]: (
+    <button
+      class={`button is-rounded is-small has-text-weight-semibold has-background-danger has-border-danger`}
+    >
+      Canceled
+    </button>
+  ),
+};
+
+const IconAndText = ({ endTime, status }) => {
+  const { diffDuration } = parseDateFromServer(endTime);
+  return status === FilterValues.active ? (
+    <>
+      <Svg name="Active" />
+      <p className="has-text-black has-text-weight-bold p-0 is-size-7 ml-1">
+        {diffDuration} left
+      </p>
+    </>
+  ) : null;
+};
+
+const FlipCardFooter = ({ id, voted, endTime, computedStatus }) => {
+  const status = FilterValues[computedStatus] ?? FilterValues.closed;
+
+  return (
+    <div className="px-4 pb-4 is-flex is-align-items-center">
+      {status === FilterValues.active && voted ? (
+        <span className="is-flex has-text-weight-bold is-size-7 pt-2 pb-1">
+          <Svg
+            name="CheckMark"
+            height="15"
+            width="15"
+            circleFill="white"
+            checkFill={'#F4AF4A'}
+            style={{
+              border: `2px solid #F4AF4A`,
+              borderRadius: '50%',
+              marginRight: '6.5px',
+            }}
+          />
+          You've Already Voted
+        </span>
+      ) : (
+        <>
+          <p className="has-text-grey px-0 smaller-text">
+            {STATUS_BUTTONS[status] ?? null}
+          </p>
+          <div className="is-flex ml-2">
+            <IconAndText
+              voted={voted}
+              endTime={endTime}
+              status={status}
+              id={id}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FlipCardFooter;

--- a/frontend/packages/client/src/components/FlipsContainer/FlipCardHeader.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipCardHeader.js
@@ -1,0 +1,10 @@
+import Blockies from 'react-blockies';
+
+export default function FlipCardHeader({ address }) {
+  return (
+    <div className="is-flex is-align-items-center flex-1 p-4">
+      <Blockies seed={address} size={6} scale={4} className="blockies mr-2" />
+      <p className="is-size-6">{address}</p>
+    </div>
+  );
+}

--- a/frontend/packages/client/src/components/FlipsContainer/FlipsCard.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipsCard.js
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom';
+import FlipCardBody from './FlipCardBody';
+import FlipCardFooter from './FlipCardFooter';
+import FlipCardHeader from './FlipCardHeader';
+import classes from './index.module.scss';
+
+export default function FlipsCard({ pr = {}, style }) {
+  const { body, creatorAddr, name, id, voted, endTime, computedStatus } = pr;
+  return (
+    <Link
+      to={`/community/${pr.communityId}/proposal/${pr.id}`}
+      className={`${classes.linkContainer} column is-4`}
+    >
+      <div className="border-light rounded-sm transition-all" style={style}>
+        <FlipCardHeader address={creatorAddr} />
+        <FlipCardBody name={name} body={body} />
+        <FlipCardFooter
+          id={id}
+          voted={voted}
+          endTime={endTime}
+          computedStatus={computedStatus}
+        />
+      </div>
+    </Link>
+  );
+}

--- a/frontend/packages/client/src/components/FlipsContainer/FlipsList.js
+++ b/frontend/packages/client/src/components/FlipsContainer/FlipsList.js
@@ -1,0 +1,17 @@
+import Loader from '../Loader';
+import FlipsCards from './FlipsCard';
+
+const FlipsList = ({ proposals, initialLoading }) => {
+  return (
+    <>
+      {initialLoading && <Loader fullHeight />}
+      <div className="columns is-variable is-3 is-multiline">
+        {(proposals ?? []).map((pr, i) => (
+          <FlipsCards pr={pr} key={i} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default FlipsList;

--- a/frontend/packages/client/src/components/FlipsContainer/index.js
+++ b/frontend/packages/client/src/components/FlipsContainer/index.js
@@ -34,7 +34,7 @@ const FlipsContainer = () => {
 
   return (
     <div>
-      <h1 className={`is-uppercase has-text-weight-bold mb-5`}>Flips</h1>
+      <h1 className={`is-uppercase has-text-weight-bold mb-5`}>Flow Flip's</h1>
       <FlipsList proposals={updatedList} initialLoading={initialLoading} />
       <BrowseButton path={`/community/${COMMUNITY_ID}`} label={'Show more'} />
     </div>

--- a/frontend/packages/client/src/components/FlipsContainer/index.js
+++ b/frontend/packages/client/src/components/FlipsContainer/index.js
@@ -1,0 +1,47 @@
+import { BrowseButton } from 'components';
+import { useCommunityProposalsWithVotes } from 'hooks';
+import FlipsList from './FlipsList';
+
+const COMMUNITY_ID = 1;
+
+const FlipsContainer = () => {
+  // Two requests are made to the backend:
+  // one will bring all active and pending proposals: "inprogress"
+  // the other will bring all closed and cancelled proposals: "terminated"
+  const { data: activeProposals, loading: loadingActiveProposals } =
+    useCommunityProposalsWithVotes({
+      communityId: COMMUNITY_ID,
+      count: 25,
+      status: 'inprogress',
+      scrollToFetchMore: false,
+    });
+  const { data: remainingProposals, loading: loadingProposals } =
+    useCommunityProposalsWithVotes({
+      communityId: COMMUNITY_ID,
+      count: 10,
+      status: 'terminated',
+    });
+
+  const updatedList = [];
+  if (activeProposals) {
+    updatedList.push(...activeProposals);
+  }
+  if (remainingProposals) {
+    updatedList.push(...remainingProposals);
+  }
+  if (updatedList.length > 3) {
+    updatedList.length = 3;
+  }
+
+  const initialLoading = loadingProposals || loadingActiveProposals;
+
+  return (
+    <div>
+      <h1 className={`is-uppercase has-text-weight-bold mb-5`}>Flips</h1>
+      <FlipsList proposals={updatedList} initialLoading={initialLoading} />
+      <BrowseButton path={`/community/${COMMUNITY_ID}`} label={'Show more'} />
+    </div>
+  );
+};
+
+export default FlipsContainer;

--- a/frontend/packages/client/src/components/FlipsContainer/index.js
+++ b/frontend/packages/client/src/components/FlipsContainer/index.js
@@ -1,5 +1,6 @@
 import { BrowseButton } from 'components';
 import { useCommunityProposalsWithVotes } from 'hooks';
+import { getUpdatedFlipsData } from '../../helpers';
 import FlipsList from './FlipsList';
 
 const COMMUNITY_ID = 1;
@@ -8,32 +9,28 @@ const FlipsContainer = () => {
   // Two requests are made to the backend:
   // one will bring all active and pending proposals: "inprogress"
   // the other will bring all closed and cancelled proposals: "terminated"
-  const { data: activeProposals, loading: loadingActiveProposals } =
+  const { data: liveFLIPs, loading: loadingLiveFLIPs } =
     useCommunityProposalsWithVotes({
       communityId: COMMUNITY_ID,
       count: 25,
       status: 'inprogress',
       scrollToFetchMore: false,
     });
-  const { data: remainingProposals, loading: loadingProposals } =
+  const { data: concludedFLIPs, loading: loadingConcludedFLIPs } =
     useCommunityProposalsWithVotes({
       communityId: COMMUNITY_ID,
       count: 10,
       status: 'terminated',
     });
 
-  const updatedList = [];
-  if (activeProposals) {
-    updatedList.push(...activeProposals);
-  }
-  if (remainingProposals) {
-    updatedList.push(...remainingProposals);
-  }
-  if (updatedList.length > 3) {
-    updatedList.length = 3;
-  }
+  let updatedList = getUpdatedFlipsData({
+    liveProposals: liveFLIPs,
+    concludedProposals: concludedFLIPs,
+  });
 
-  const initialLoading = loadingProposals || loadingActiveProposals;
+  updatedList.length = 3;
+
+  const initialLoading = loadingConcludedFLIPs || loadingLiveFLIPs;
 
   return (
     <div>

--- a/frontend/packages/client/src/components/FlipsContainer/index.module.scss
+++ b/frontend/packages/client/src/components/FlipsContainer/index.module.scss
@@ -1,0 +1,3 @@
+.linkContainer {
+  color: inherit;
+}

--- a/frontend/packages/client/src/components/index.js
+++ b/frontend/packages/client/src/components/index.js
@@ -57,5 +57,6 @@ export {
 export { default as StatusPill } from './StatusPill';
 export { default as StyledStatusPill } from './StyledStatusPill';
 export { default as FilterPill } from './FilterPill';
-export { default as BrowseCommunityButton } from './BrowseCommunityButton';
+export { default as BrowseButton } from './BrowseButton';
+export { default as FlipsContainer } from './FlipsContainer';
 export * from './Proposal';

--- a/frontend/packages/client/src/helpers/index.js
+++ b/frontend/packages/client/src/helpers/index.js
@@ -1,0 +1,21 @@
+const getPriorityBasedProposals = (proposals = []) => {
+  const currentDate = new Date();
+  if (proposals) {
+    const updatedProposal = proposals;
+    updatedProposal.sort((a, b) => {
+      // The calculations are based on the endTime of proposals,
+      // which should be close to the current date
+      const differenceA = Math.abs(new Date(a.endTime) - currentDate);
+      const differenceB = Math.abs(new Date(b.endTime) - currentDate);
+      return differenceA - differenceB;
+    });
+    return updatedProposal ?? [];
+  }
+  return [];
+};
+
+export const getUpdatedFlipsData = ({ liveProposals, concludedProposals }) => {
+  const sortedLiveFlips = getPriorityBasedProposals(liveProposals);
+  const sortedConcludedFlips = getPriorityBasedProposals(concludedProposals);
+  return [...sortedLiveFlips, ...sortedConcludedFlips];
+};

--- a/frontend/packages/client/src/pages/Home.js
+++ b/frontend/packages/client/src/pages/Home.js
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import { useWebContext } from 'contexts/Web3';
 import {
-  BrowseCommunityButton,
+  BrowseButton,
   FadeIn,
+  FlipsContainer,
   HomeFooter,
   HomeHeader,
   Loader,
@@ -15,6 +16,7 @@ import {
   useLocalStorage,
   useUserCommunities,
 } from 'hooks';
+import classNames from 'classnames';
 import SectionContainer from 'layout/SectionContainer';
 
 export default function HomePage() {
@@ -56,6 +58,11 @@ export default function HomePage() {
 
   const showLoader = loading || loadingFeaturedCommunities;
 
+  const featureCommunitiesClasses = classNames({
+    'has-background-light-grey': !isMyCommunitiesVisible,
+    'pt-5': true,
+  });
+
   return (
     <>
       {showToolTip && (
@@ -74,6 +81,9 @@ export default function HomePage() {
       )}
       {!showLoader && (
         <FadeIn>
+          <SectionContainer classNames="pt-5">
+            <FlipsContainer />
+          </SectionContainer>
           {isMyCommunitiesVisible && (
             <SectionContainer classNames="has-background-light-grey">
               <CommunitiesPresenter
@@ -83,12 +93,15 @@ export default function HomePage() {
               />
             </SectionContainer>
           )}
-          <SectionContainer classNames="pt-5">
+          <SectionContainer classNames={featureCommunitiesClasses}>
             <CommunitiesPresenter
               title="Featured Communities"
               communities={featuredCommunities}
             />
-            <BrowseCommunityButton />
+            <BrowseButton
+              path={'/browse-communities'}
+              label={'Browse All Communities'}
+            />
           </SectionContainer>
         </FadeIn>
       )}


### PR DESCRIPTION
# Pull Request
related to #5
## Description
- Add a section on landing page of flow that shows flips of that particular block chain community.
-  Change BrowseCommunityButton Component -> generalised navigation  button component.

## Affected Modules
- Main Landing page will now have a section called the FLIPS (Flow Improvement Proposal) which will show the latest 3 FLIPS.

## Things to consider - 
- All the proposals are FLIPS inside the blockchain community.
- Community ID for the main community is a constant with value 1.
- Always there will be an image inside the description of a particular FLIP. If not, we are providing a default image. (@vishalchangrani TBD)
- The FLIPS are shown in the order of Active flips first and terminated flips in the end if any condition met.
- FLIP tile appears at the top level but below the banner (If there's any).
- If > 3 FLIPs are live show the top-3 arranged by end-date (end-date is the closest to current date).
- If < 3 FLIPs are live, show the live ones + most recently finished/ concluded FLIPs. 

## Checklist
- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have assigned the PR to the appropriate reviewer(s) for their feedback.