### PR TITLE
Bug fix for one-address-one-vote strategy

### DIFF
--- a/frontend/packages/client/src/networks.js
+++ b/frontend/packages/client/src/networks.js
@@ -22,7 +22,13 @@ const networksConfig = {
       // '0x9d2e44203cb13051', // Ledger
       '0x82ec283f88a62e65', // Dapper Wallet
     ],
-    strategiesConfig: {},
+    strategiesConfig: {
+      'one-address-one-vote': {
+        name: 'FlowToken',
+        addr: '0x7e60df042a9c0868',
+        publicPath: 'flowTokenBalance',
+      },
+    },
     flowAddress: {
       contractName: 'FlowToken',
       contractAddr: '0x7e60df042a9c0868',
@@ -38,7 +44,13 @@ const networksConfig = {
       // '0xe5cd26afebe62781', // Ledger
       '0xead892083b3e2c6c', // Dapper Wallet
     ],
-    strategiesConfig: {},
+    strategiesConfig: {
+      'one-address-one-vote': {
+        name: 'FlowToken',
+        addr: '0x1654653399040a61',
+        publicPath: 'flowTokenBalance',
+      },
+    },
     flowAddress: {
       contractName: 'FlowToken',
       contractAddr: '0x1654653399040a61',


### PR DESCRIPTION
# Pull Request
Related to #14 
## Description
- While creating a community in step number 4, one of the strategies called the One-Address-One-Vote was not working.

## Affected Modules
  - Creating Community - https://{localhost:3000}/#/community/create.
  - Updating Community - http://{localhost:3000}/#/community/2/edit.

## The Issue-
There was a special case for this particular strategy inside StrategyEditorModal.js which takes value from the network configurations. We need to add the particular configurations inside that network.js file.

## Demo -
https://github.com/onflow/CAST/assets/135014949/10882b46-1d82-499a-b2dc-b4487fa46259


## Checklist
- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have assigned the PR to the appropriate reviewer(s) for their feedback.
- [x] Are all the improvements/development done?